### PR TITLE
Initialize TradIA infrastructure

### DIFF
--- a/tradia/backend/app/main.py
+++ b/tradia/backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/health')
+def health_check():
+    return {"status": "ok"}

--- a/tradia/backend/requirements.txt
+++ b/tradia/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.109.0
+uvicorn[standard]==0.25.0

--- a/tradia/docker-compose.yml
+++ b/tradia/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:13
+    environment:
+      POSTGRES_USER: tradia
+      POSTGRES_PASSWORD: tradia
+      POSTGRES_DB: tradia
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  mongodb:
+    image: mongo:5
+    volumes:
+      - mongo_data:/data/db
+
+  backend:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.backend
+    volumes:
+      - ./backend:/app/backend
+    depends_on:
+      - postgres
+      - mongodb
+    environment:
+      - DATABASE_URL=postgresql+psycopg2://tradia:tradia@postgres/tradia
+      - MONGODB_URL=mongodb://mongodb:27017
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.frontend
+    volumes:
+      - ./frontend:/app/frontend
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+    ports:
+      - "80:80"
+    depends_on:
+      - frontend
+      - backend
+
+volumes:
+  postgres_data:
+  mongo_data:

--- a/tradia/docker/Dockerfile.backend
+++ b/tradia/docker/Dockerfile.backend
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend ./backend
+
+EXPOSE 8000
+
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tradia/docker/Dockerfile.frontend
+++ b/tradia/docker/Dockerfile.frontend
@@ -1,0 +1,15 @@
+FROM node:18-alpine as builder
+WORKDIR /app
+
+COPY frontend/package.json ./
+COPY frontend/package-lock.json ./
+RUN npm install
+
+COPY frontend ./
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=builder /app .
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/tradia/frontend/package.json
+++ b/tradia/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "tradia-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.3.5"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.27"
+  }
+}

--- a/tradia/frontend/pages/_app.js
+++ b/tradia/frontend/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/tradia/frontend/pages/index.js
+++ b/tradia/frontend/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <h1 className="text-2xl font-bold">TradIA MVP funcionando</h1>
+    </div>
+  );
+}

--- a/tradia/frontend/postcss.config.js
+++ b/tradia/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tradia/frontend/styles/globals.css
+++ b/tradia/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tradia/frontend/tailwind.config.js
+++ b/tradia/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./pages/**/*.{js,jsx,ts,tsx}", "./components/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tradia/nginx/default.conf
+++ b/tradia/nginx/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+
+    location /api/ {
+        proxy_pass http://backend:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location / {
+        proxy_pass http://frontend:3000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
## Summary
- add initial folder layout for TradIA MVP
- docker-compose with backend, frontend, postgres and mongo
- Dockerfiles for backend and frontend images
- minimal FastAPI backend with /health endpoint
- minimal Next.js frontend showing initial message
- nginx config for reverse proxy

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884f6a0d31c8332ac947c7c4fa85a8a